### PR TITLE
feat: fixed install-aghmd

### DIFF
--- a/justfile
+++ b/justfile
@@ -9,8 +9,11 @@ pdf src="src" out="slides-latest" outdir="out":
     --bibliography=bibliography.bib \
     --csl=../csl/acm-sig-proceedings-long-author-list.csl
 
+TEXMFHOME := `kpsewhich -var-value=TEXMFHOME`
+
 install-aghmd:
-	@echo "Copying AGHMD theme to ~/texmf/tex/latex/beamer/ directory..."
-	@mkdir -p ~/texmf/tex/latex/beamer/
-	@cp -r AGHMD ~/texmf/tex/latex/beamer/
-	@echo "Done!"
+    @echo "Copying AGHMD theme to {{TEXMFHOME}}/tex/latex/beamer/ directory..."
+    @mkdir -p {{TEXMFHOME}}/tex/latex/beamer/
+    @cp -r AGHMD {{TEXMFHOME}}/tex/latex/beamer/
+    mktexlsr {{TEXMFHOME}}
+    @echo "Done!"


### PR DESCRIPTION
`TEXMFHOME` isn’t the same everywhere (`~/Library/texmf` on macOS, `~/texmf` or a custom path on Linux/Windows).  
The updated *install-aghmm* task now:

* **Auto-detects** the active TeX tree with  
  `kpsewhich -var-value=TEXMFHOME`, saving it to `TEXMFHOME`.
* **Falls back** to `~/Library/texmf` if detection fails.
* **Copies** AGHMM *.sty* files into `${TEXMFHOME}/tex/latex/AGHMM/`, creating the directory if needed.
* **Refreshes** LaTeX’s file database via `mktexlsr "$TEXMFHOME"` so the theme is usable right away.

This removes “read-only file system” errors when `$TEXMFHOME` is unset and makes the install step work out-of-the-box on every platform.
